### PR TITLE
Fix: add html line breaks to markdown summary

### DIFF
--- a/docs/samples/xUnit.md
+++ b/docs/samples/xUnit.md
@@ -5,8 +5,8 @@
 <p>
 <strong>Overall Result:</strong> ❌ Fail <br />
 <strong>Pass Rate:</strong> 33.33% <br />
-<strong>Run Duration:</strong> 1s 720ms <br />
-<strong>Date:</strong> 2020-06-03 08:41:18 - 2020-06-03 08:41:19 <br />
+<strong>Run Duration:</strong> 1s 766ms <br />
+<strong>Date:</strong> 2020-06-03 19:49:26 - 2020-06-03 19:49:28 <br />
 <strong>Framework:</strong> .NETCoreApp,Version=v3.1 <br />
 <strong>Total Tests:</strong> 6 <br />
 </p>
@@ -48,18 +48,21 @@
 <tr>
 <td> ✔️ Passed </td>
 <td>SampleProject.xUnit.TestServiceTests.TestTheory(expected: True)</td>
-<td>8ms</td>
+<td>7ms</td>
 </tr>
 <tr>
 <td> ❌ Failed </td>
 <td>SampleProject.xUnit.TestServiceTests.TestTheory(expected: False)<blockquote><details>
-<summary>Error Message</summary>
+<summary>Error</summary>
+<strong>Message:</strong>
 <pre><code>Assert.Equal() Failure
 Expected: False
 Actual:   True</code></pre>
+<strong>Stack Trace:</strong>
+<pre><code>   at SampleProject.xUnit.TestServiceTests.TestTheory(Boolean expected) in C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs:line 29</code></pre>
 </details></blockquote>
 </td>
-<td>4ms</td>
+<td>3ms</td>
 </tr>
 <tr>
 <td> ⚠️ Skipped </td>
@@ -69,8 +72,12 @@ Actual:   True</code></pre>
 <tr>
 <td> ❌ Failed </td>
 <td>SampleProject.xUnit.TestServiceTests.TestThrowingException<blockquote><details>
-<summary>Error Message</summary>
+<summary>Error</summary>
+<strong>Message:</strong>
 <pre><code>System.Exception : Pretty good exception</code></pre>
+<strong>Stack Trace:</strong>
+<pre><code>   at SampleProject.TestService.GetException() in C:\github\LiquidTestReports\test\SampleProject\SampleProject\TestService.cs:line 19
+   at SampleProject.xUnit.TestServiceTests.TestThrowingException() in C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs:line 54</code></pre>
 </details></blockquote>
 </td>
 <td>1ms</td>
@@ -83,10 +90,13 @@ Actual:   True</code></pre>
 <tr>
 <td> ❌ Failed </td>
 <td>SampleProject.xUnit.TestServiceTests.FailTest<blockquote><details>
-<summary>Error Message</summary>
+<summary>Error</summary>
+<strong>Message:</strong>
 <pre><code>Assert.True() Failure
 Expected: True
 Actual:   False</code></pre>
+<strong>Stack Trace:</strong>
+<pre><code>   at SampleProject.xUnit.TestServiceTests.FailTest() in C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs:line 65</code></pre>
 </details></blockquote>
 </td>
 <td>1ms</td>
@@ -100,48 +110,48 @@ Actual:   False</code></pre>
 <summary>Informational</summary>
 <pre><code>
 [xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.1 (64-bit .NET Core 3.1.3)
-[xUnit.net 00:00:00.58]   Discovering: SampleProject.xUnit
-[xUnit.net 00:00:00.67]   Discovered:  SampleProject.xUnit
-[xUnit.net 00:00:00.67]   Starting:    SampleProject.xUnit
-[xUnit.net 00:00:00.82]       Assert.Equal() Failure
-[xUnit.net 00:00:00.82]       Expected: False
-[xUnit.net 00:00:00.82]       Actual:   True
-[xUnit.net 00:00:00.82]       Stack Trace:
-[xUnit.net 00:00:00.82]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(29,0): at SampleProject.xUnit.TestServiceTests.TestTheory(Boolean expected)
-[xUnit.net 00:00:00.82]       Output:
-[xUnit.net 00:00:00.82]         Running SampleProject.Tests.xUnit tests
-[xUnit.net 00:00:00.82]       Skipped
-[xUnit.net 00:00:00.82]       System.Exception : Pretty good exception
-[xUnit.net 00:00:00.82]       Stack Trace:
-[xUnit.net 00:00:00.82]         C:\github\LiquidTestReports\test\SampleProject\SampleProject\TestService.cs(19,0): at SampleProject.TestService.GetException()
-[xUnit.net 00:00:00.82]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(54,0): at SampleProject.xUnit.TestServiceTests.TestThrowingException()
-[xUnit.net 00:00:00.82]       Output:
-[xUnit.net 00:00:00.82]         Running SampleProject.Tests.xUnit tests
-[xUnit.net 00:00:00.83]       Assert.True() Failure
-[xUnit.net 00:00:00.83]       Expected: True
-[xUnit.net 00:00:00.83]       Actual:   False
-[xUnit.net 00:00:00.83]       Stack Trace:
-[xUnit.net 00:00:00.83]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(65,0): at SampleProject.xUnit.TestServiceTests.FailTest()
-[xUnit.net 00:00:00.83]       Output:
-[xUnit.net 00:00:00.83]         Running SampleProject.Tests.xUnit tests
-[xUnit.net 00:00:00.83]         This test will fail
-[xUnit.net 00:00:00.83]   Finished:    SampleProject.xUnit
+[xUnit.net 00:00:00.57]   Discovering: SampleProject.xUnit
+[xUnit.net 00:00:00.66]   Discovered:  SampleProject.xUnit
+[xUnit.net 00:00:00.66]   Starting:    SampleProject.xUnit
+[xUnit.net 00:00:00.79]       Assert.Equal() Failure
+[xUnit.net 00:00:00.79]       Expected: False
+[xUnit.net 00:00:00.79]       Actual:   True
+[xUnit.net 00:00:00.79]       Stack Trace:
+[xUnit.net 00:00:00.79]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(29,0): at SampleProject.xUnit.TestServiceTests.TestTheory(Boolean expected)
+[xUnit.net 00:00:00.79]       Output:
+[xUnit.net 00:00:00.79]         Running SampleProject.Tests.xUnit tests
+[xUnit.net 00:00:00.79]       Skipped
+[xUnit.net 00:00:00.79]       System.Exception : Pretty good exception
+[xUnit.net 00:00:00.79]       Stack Trace:
+[xUnit.net 00:00:00.79]         C:\github\LiquidTestReports\test\SampleProject\SampleProject\TestService.cs(19,0): at SampleProject.TestService.GetException()
+[xUnit.net 00:00:00.79]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(54,0): at SampleProject.xUnit.TestServiceTests.TestThrowingException()
+[xUnit.net 00:00:00.79]       Output:
+[xUnit.net 00:00:00.79]         Running SampleProject.Tests.xUnit tests
+[xUnit.net 00:00:00.79]       Assert.True() Failure
+[xUnit.net 00:00:00.79]       Expected: True
+[xUnit.net 00:00:00.79]       Actual:   False
+[xUnit.net 00:00:00.79]       Stack Trace:
+[xUnit.net 00:00:00.79]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(65,0): at SampleProject.xUnit.TestServiceTests.FailTest()
+[xUnit.net 00:00:00.79]       Output:
+[xUnit.net 00:00:00.79]         Running SampleProject.Tests.xUnit tests
+[xUnit.net 00:00:00.79]         This test will fail
+[xUnit.net 00:00:00.80]   Finished:    SampleProject.xUnit
 </code></pre>
 </details>
 
 <details>
 <summary>Warning</summary>
 <pre><code>
-[xUnit.net 00:00:00.82]     SampleProject.xUnit.TestServiceTests.SkipTest [SKIP]
+[xUnit.net 00:00:00.79]     SampleProject.xUnit.TestServiceTests.SkipTest [SKIP]
 </code></pre>
 </details>
 
 <details>
 <summary>Error</summary>
 <pre><code>
-[xUnit.net 00:00:00.82]     SampleProject.xUnit.TestServiceTests.TestTheory(expected: False) [FAIL]
-[xUnit.net 00:00:00.82]     SampleProject.xUnit.TestServiceTests.TestThrowingException [FAIL]
-[xUnit.net 00:00:00.83]     SampleProject.xUnit.TestServiceTests.FailTest [FAIL]
+[xUnit.net 00:00:00.79]     SampleProject.xUnit.TestServiceTests.TestTheory(expected: False) [FAIL]
+[xUnit.net 00:00:00.79]     SampleProject.xUnit.TestServiceTests.TestThrowingException [FAIL]
+[xUnit.net 00:00:00.79]     SampleProject.xUnit.TestServiceTests.FailTest [FAIL]
 </code></pre>
 </details>
 

--- a/docs/samples/xUnit.md
+++ b/docs/samples/xUnit.md
@@ -1,12 +1,16 @@
 ﻿
 # Test Run
 ### Run Summary
-**Overall Result:** ❌ Fail
-**Pass Rate:** 33.33%
-**Run Duration:** 2s 667ms
-**Date:** 2020-06-03 07:59:50 - 2020-06-03 07:59:52
-**Framework:** .NETCoreApp,Version=v3.1
-**Total Tests:** 6
+
+<p>
+<strong>Overall Result:</strong> ❌ Fail <br />
+<strong>Pass Rate:</strong> 33.33% <br />
+<strong>Run Duration:</strong> 1s 720ms <br />
+<strong>Date:</strong> 2020-06-03 08:41:18 - 2020-06-03 08:41:19 <br />
+<strong>Framework:</strong> .NETCoreApp,Version=v3.1 <br />
+<strong>Total Tests:</strong> 6 <br />
+</p>
+
 <table>
 <thead>
 <tr>
@@ -44,7 +48,7 @@
 <tr>
 <td> ✔️ Passed </td>
 <td>SampleProject.xUnit.TestServiceTests.TestTheory(expected: True)</td>
-<td>9ms</td>
+<td>8ms</td>
 </tr>
 <tr>
 <td> ❌ Failed </td>
@@ -55,7 +59,7 @@ Expected: False
 Actual:   True</code></pre>
 </details></blockquote>
 </td>
-<td>7ms</td>
+<td>4ms</td>
 </tr>
 <tr>
 <td> ⚠️ Skipped </td>
@@ -69,7 +73,7 @@ Actual:   True</code></pre>
 <pre><code>System.Exception : Pretty good exception</code></pre>
 </details></blockquote>
 </td>
-<td>< 1ms</td>
+<td>1ms</td>
 </tr>
 <tr>
 <td> ✔️ Passed </td>
@@ -85,7 +89,7 @@ Expected: True
 Actual:   False</code></pre>
 </details></blockquote>
 </td>
-<td>< 1ms</td>
+<td>1ms</td>
 </tr>
 </tbody>
 </table>
@@ -96,48 +100,48 @@ Actual:   False</code></pre>
 <summary>Informational</summary>
 <pre><code>
 [xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.1 (64-bit .NET Core 3.1.3)
-[xUnit.net 00:00:00.89]   Discovering: SampleProject.xUnit
-[xUnit.net 00:00:00.97]   Discovered:  SampleProject.xUnit
-[xUnit.net 00:00:00.98]   Starting:    SampleProject.xUnit
-[xUnit.net 00:00:01.13]       Assert.Equal() Failure
-[xUnit.net 00:00:01.13]       Expected: False
-[xUnit.net 00:00:01.13]       Actual:   True
-[xUnit.net 00:00:01.13]       Stack Trace:
-[xUnit.net 00:00:01.13]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(29,0): at SampleProject.xUnit.TestServiceTests.TestTheory(Boolean expected)
-[xUnit.net 00:00:01.13]       Output:
-[xUnit.net 00:00:01.14]         Running SampleProject.Tests.xUnit tests
-[xUnit.net 00:00:01.14]       Skipped
-[xUnit.net 00:00:01.14]       System.Exception : Pretty good exception
-[xUnit.net 00:00:01.14]       Stack Trace:
-[xUnit.net 00:00:01.14]         C:\github\LiquidTestReports\test\SampleProject\SampleProject\TestService.cs(19,0): at SampleProject.TestService.GetException()
-[xUnit.net 00:00:01.14]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(54,0): at SampleProject.xUnit.TestServiceTests.TestThrowingException()
-[xUnit.net 00:00:01.14]       Output:
-[xUnit.net 00:00:01.14]         Running SampleProject.Tests.xUnit tests
-[xUnit.net 00:00:01.14]       Assert.True() Failure
-[xUnit.net 00:00:01.14]       Expected: True
-[xUnit.net 00:00:01.14]       Actual:   False
-[xUnit.net 00:00:01.14]       Stack Trace:
-[xUnit.net 00:00:01.14]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(65,0): at SampleProject.xUnit.TestServiceTests.FailTest()
-[xUnit.net 00:00:01.14]       Output:
-[xUnit.net 00:00:01.14]         Running SampleProject.Tests.xUnit tests
-[xUnit.net 00:00:01.14]         This test will fail
-[xUnit.net 00:00:01.15]   Finished:    SampleProject.xUnit
+[xUnit.net 00:00:00.58]   Discovering: SampleProject.xUnit
+[xUnit.net 00:00:00.67]   Discovered:  SampleProject.xUnit
+[xUnit.net 00:00:00.67]   Starting:    SampleProject.xUnit
+[xUnit.net 00:00:00.82]       Assert.Equal() Failure
+[xUnit.net 00:00:00.82]       Expected: False
+[xUnit.net 00:00:00.82]       Actual:   True
+[xUnit.net 00:00:00.82]       Stack Trace:
+[xUnit.net 00:00:00.82]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(29,0): at SampleProject.xUnit.TestServiceTests.TestTheory(Boolean expected)
+[xUnit.net 00:00:00.82]       Output:
+[xUnit.net 00:00:00.82]         Running SampleProject.Tests.xUnit tests
+[xUnit.net 00:00:00.82]       Skipped
+[xUnit.net 00:00:00.82]       System.Exception : Pretty good exception
+[xUnit.net 00:00:00.82]       Stack Trace:
+[xUnit.net 00:00:00.82]         C:\github\LiquidTestReports\test\SampleProject\SampleProject\TestService.cs(19,0): at SampleProject.TestService.GetException()
+[xUnit.net 00:00:00.82]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(54,0): at SampleProject.xUnit.TestServiceTests.TestThrowingException()
+[xUnit.net 00:00:00.82]       Output:
+[xUnit.net 00:00:00.82]         Running SampleProject.Tests.xUnit tests
+[xUnit.net 00:00:00.83]       Assert.True() Failure
+[xUnit.net 00:00:00.83]       Expected: True
+[xUnit.net 00:00:00.83]       Actual:   False
+[xUnit.net 00:00:00.83]       Stack Trace:
+[xUnit.net 00:00:00.83]         C:\github\LiquidTestReports\test\SampleProject\SampleProject.Tests.xUnit\TestServiceTests.cs(65,0): at SampleProject.xUnit.TestServiceTests.FailTest()
+[xUnit.net 00:00:00.83]       Output:
+[xUnit.net 00:00:00.83]         Running SampleProject.Tests.xUnit tests
+[xUnit.net 00:00:00.83]         This test will fail
+[xUnit.net 00:00:00.83]   Finished:    SampleProject.xUnit
 </code></pre>
 </details>
 
 <details>
 <summary>Warning</summary>
 <pre><code>
-[xUnit.net 00:00:01.14]     SampleProject.xUnit.TestServiceTests.SkipTest [SKIP]
+[xUnit.net 00:00:00.82]     SampleProject.xUnit.TestServiceTests.SkipTest [SKIP]
 </code></pre>
 </details>
 
 <details>
 <summary>Error</summary>
 <pre><code>
-[xUnit.net 00:00:01.13]     SampleProject.xUnit.TestServiceTests.TestTheory(expected: False) [FAIL]
-[xUnit.net 00:00:01.14]     SampleProject.xUnit.TestServiceTests.TestThrowingException [FAIL]
-[xUnit.net 00:00:01.14]     SampleProject.xUnit.TestServiceTests.FailTest [FAIL]
+[xUnit.net 00:00:00.82]     SampleProject.xUnit.TestServiceTests.TestTheory(expected: False) [FAIL]
+[xUnit.net 00:00:00.82]     SampleProject.xUnit.TestServiceTests.TestThrowingException [FAIL]
+[xUnit.net 00:00:00.83]     SampleProject.xUnit.TestServiceTests.FailTest [FAIL]
 </code></pre>
 </details>
 

--- a/src/LiquidTestReports.Markdown/Resources/MdReport.md
+++ b/src/LiquidTestReports.Markdown/Resources/MdReport.md
@@ -69,8 +69,11 @@
 <td> {{- result.test_case.display_name -}}
 {%- if result.outcome == 'Failed' and library.parameters.IncludeMessages == true -%}
 <blockquote><details>
-<summary>Error Message</summary>
+<summary>Error</summary>
+<strong>Message:</strong>
 <pre><code>{{result.error_message}}</code></pre>
+<strong>Stack Trace:</strong>
+<pre><code>{{result.error_stack_trace}}</code></pre>
 </details></blockquote>
 {%- endif -%}
 </td>

--- a/src/LiquidTestReports.Markdown/Resources/MdReport.md
+++ b/src/LiquidTestReports.Markdown/Resources/MdReport.md
@@ -18,12 +18,16 @@
 
 # {{ library.parameters.Title }}
 ### Run Summary
-**Overall Result:** {{overall}}
-**Pass Rate:** {{pass_percentage}}%
-**Run Duration:** {{ run.elapsed_time_in_running_tests | format_duration }}
-**Date:** {{ run.started | local_time | date: '%Y-%m-%d %H:%M:%S' }} - {{ run.finished | local_time | date: '%Y-%m-%d %H:%M:%S' }}
-**Framework:** {{ parameters.TargetFramework }}
-**Total Tests:** {{total}}
+
+<p>
+<strong>Overall Result:</strong> {{overall}} <br />
+<strong>Pass Rate:</strong> {{pass_percentage}}% <br />
+<strong>Run Duration:</strong> {{ run.elapsed_time_in_running_tests | format_duration }} <br />
+<strong>Date:</strong> {{ run.started | local_time | date: '%Y-%m-%d %H:%M:%S' }} - {{ run.finished | local_time | date: '%Y-%m-%d %H:%M:%S' }} <br />
+<strong>Framework:</strong> {{ parameters.TargetFramework }} <br />
+<strong>Total Tests:</strong> {{total}} <br />
+</p>
+
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
- Resolves summary item line breaks not appearing in GitHub preview
- Update sample
- Include error stack trace