### PR TITLE
Fix: Create drop for test result messages, and replace URIs with strings

### DIFF
--- a/src/LiquidTestReports.Core/Drops/AttachmentDrop.cs
+++ b/src/LiquidTestReports.Core/Drops/AttachmentDrop.cs
@@ -15,6 +15,6 @@ namespace LiquidTestReports.Core.Drops
 
         public string Description => _uriDataAttachment.Description;
 
-        public Uri Uri => _uriDataAttachment.Uri;
+        public string Uri => _uriDataAttachment.Uri.ToString();
     }
 }

--- a/src/LiquidTestReports.Core/Drops/AttachmentSetDrop.cs
+++ b/src/LiquidTestReports.Core/Drops/AttachmentSetDrop.cs
@@ -15,7 +15,7 @@ namespace LiquidTestReports.Core.Drops
             _attachmentSet = attachmentSet;
         }
 
-        public Uri Uri => _attachmentSet.Uri;
+        public string Uri => _attachmentSet.Uri.ToString();
 
         public string DisplayName => _attachmentSet.DisplayName;
 

--- a/src/LiquidTestReports.Core/Drops/TestCaseDrop.cs
+++ b/src/LiquidTestReports.Core/Drops/TestCaseDrop.cs
@@ -21,7 +21,7 @@ namespace LiquidTestReports.Core.Drops
 
         public string DisplayName => _testCase.DisplayName;
 
-        public Uri ExecutorUri => _testCase.ExecutorUri;
+        public string ExecutorUri => _testCase.ExecutorUri.ToString();
 
         public string Source => _testCase.Source;
 

--- a/src/LiquidTestReports.Core/Drops/TestResultDrop.cs
+++ b/src/LiquidTestReports.Core/Drops/TestResultDrop.cs
@@ -17,7 +17,7 @@ namespace LiquidTestReports.Core.Drops
 
         public TestCaseDrop TestCase => new TestCaseDrop(_testResult.TestCase);
 
-        public IList<AttachmentSetDrop> Attachments => _testResult.Attachments.Select(a => new AttachmentSetDrop(a)).ToList();
+        public IList<AttachmentSetDrop> AttachmentSets => _testResult.Attachments.Select(a => new AttachmentSetDrop(a)).ToList();
 
         public string Outcome => _testResult.Outcome.ToString();
 
@@ -27,7 +27,7 @@ namespace LiquidTestReports.Core.Drops
 
         public string DisplayName => _testResult.DisplayName;
 
-        public IList<TestResultMessage> Messages => _testResult.Messages;
+        public IList<TestResultMessageDrop> Messages => _testResult.Messages.Select(m => new TestResultMessageDrop(m)).ToList();
 
         public string ComputerName => _testResult.ComputerName;
 

--- a/src/LiquidTestReports.Core/Drops/TestResultMessageDrop.cs
+++ b/src/LiquidTestReports.Core/Drops/TestResultMessageDrop.cs
@@ -1,0 +1,20 @@
+﻿using DotLiquid;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace LiquidTestReports.Core.Drops
+{
+    public class TestResultMessageDrop : Drop
+    {
+        private readonly TestResultMessage _testResultMessage;
+
+        public TestResultMessageDrop(TestResultMessage testResultMessage)
+        {
+            _testResultMessage = testResultMessage;
+        }
+
+        public string Text => _testResultMessage.Text;
+
+        public string Category => _testResultMessage.Category;
+    }
+}


### PR DESCRIPTION
Fix: 
- Create drop for test result messages
- Replace URIs with strings