### PR TITLE
Added support for .NET Standard 2.0 (fixes #16)

### DIFF
--- a/src/LiquidTestReports.Core/LiquidTestReports.Core.csproj
+++ b/src/LiquidTestReports.Core/LiquidTestReports.Core.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>LiquidTestReports.Core</AssemblyName>
-    <TargetFrameworks>netstandard2.1;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <RepositoryUrl>https://github.com/kurtmkurtm/LiquidTestReports</RepositoryUrl>
     <PackageProjectUrl>https://github.com/kurtmkurtm/LiquidTestReports</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/LiquidTestReports.Custom/LiquidTestReports.Custom.csproj
+++ b/src/LiquidTestReports.Custom/LiquidTestReports.Custom.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>LiquidTestReports.Custom.TestLogger</AssemblyName>
-    <TargetFrameworks>netstandard2.1;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <RepositoryUrl>https://github.com/kurtmkurtm/LiquidTestReports</RepositoryUrl>
     <PackageProjectUrl>https://github.com/kurtmkurtm/LiquidTestReports</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/LiquidTestReports.Markdown/LiquidTestReports.Markdown.csproj
+++ b/src/LiquidTestReports.Markdown/LiquidTestReports.Markdown.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>LiquidTestReports.Markdown.TestLogger</AssemblyName>
-    <TargetFrameworks>netstandard2.1;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/kurtmkurtm/LiquidTestReports</PackageProjectUrl>
     <RepositoryUrl>https://github.com/kurtmkurtm/LiquidTestReports</RepositoryUrl>


### PR DESCRIPTION
Fixes #16.

Since none of the additional APIs that .NET Standard 2.1 provides are being called, this project can target .NET Standard 2.0. This PR makes LiquidTestReports compatible with [more consumers](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support), including:

- .NET Core 2.x
- Xamarin.iOS 10.14
- Xamarin.Mac 3.8
- Xamarin.Android 8.0
- UWP 10.0.16299 (UWP not currently supported on .NET Standard 2.1)
- Unity 2018.1 (Unity not currently supported on .NET Standard 2.1)

We'd appreciate if you could put this on NuGet ASAP so we don't have to include the binaries in our repo or release a clone of this project on NuGet with .NET Standard 2.0 support so we can utilize LiquidTestReports.

On a side note, when I ran the tests I got 18 failures in the sample projects both before and after this change.



